### PR TITLE
Add syntax proposal for relational definitions

### DIFF
--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/rules/CGen.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/rules/CGen.sdf3
@@ -4,6 +4,8 @@ imports
  
   nabl2/shared/common/CTerms
   nabl2/shared/common/Identifiers
+  nabl2/shared/common/Names
+  nabl2/shared/common/ScopeGraph
   nabl2/shared/constraints/Base
 
   nabl2/lang/common/Identifiers
@@ -37,6 +39,10 @@ context-free syntax
   RuleClause             = Constraint
   RuleClause             = NewScopes
   RuleClause.CGenRecurse = <<CGenRuleRefTop> [[ <Var> <CGenParamsTerm> <CGenTypeTerm> ]]>
+  RuleClause.ForAll		 = <
+  	forall <Occurrence>:<Var> in <Names> =\> {
+  		<{RuleClause ",\n"}+>.
+  	}>
 
 
 context-free syntax

--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
@@ -20,7 +20,7 @@ context-free syntax
 
 context-free syntax
 
-  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <Patterns>>
+  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <RelationDefPatterns>>
 
   RelationOption = Reflexivity
   RelationOption = Symmetry
@@ -29,11 +29,11 @@ context-free syntax
   RelationType.TypeSort =
   RelationType          = <: <SortRef> * <SortRef>>
 
-  Patterns = <{ <{Pattern ",\n"}*> }>
-  Patterns      = {ast("[]")}
+  RelationDefPatterns = <{ <{RelationDefPattern ",\n"}*> }>
+  RelationDefPatterns      = {ast("[]")}
   
-  Pattern = VariancePattern
-  Pattern = RelationPattern
+  RelationDefPattern = VariancePattern
+  RelationDefPattern = RelationPattern
  
   RelationPattern.Relation = <
   	<RelationDefVariant> <RelationBuildOp> <RelationDefVariant> := {

--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
@@ -5,6 +5,7 @@ imports
   nabl2/shared/common/Identifiers
   nabl2/shared/common/Relations
   nabl2/shared/common/Sorts
+  nabl2/lang/rules/CGen
 
 template options
 
@@ -19,7 +20,7 @@ context-free syntax
 
 context-free syntax
 
-  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <VariancePatterns>>
+  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <Patterns>>
 
   RelationOption = Reflexivity
   RelationOption = Symmetry
@@ -28,8 +29,23 @@ context-free syntax
   RelationType.TypeSort =
   RelationType          = <: <SortRef> * <SortRef>>
 
-  VariancePatterns      = <{ <{VariancePattern ",\n"}*> }>
-  VariancePatterns      = {ast("[]")}
+  Patterns = <{ <{Pattern ",\n"}*> }>
+  Patterns      = {ast("[]")}
+  
+  Pattern = VariancePattern
+  Pattern = RelationPattern
+ 
+  RelationPattern.Relation = <
+  	<RelationDefVariant> <RelationBuildOp> <RelationDefVariant> := {
+   		<{RuleClause ",\n"}+>.
+   	}>
+  
+  VarIds = {VarId ","}*
+  
+  
+ syntax 
+  
+  RelationDefVariant-CF.DefVariant = OpId-LEX "(" LAYOUT?-CF VarIds-CF LAYOUT?-CF ")"
  
  lexical syntax
  


### PR DESCRIPTION
To be able to define structural type relational definitions,
we propose this syntax for defining patterns on type relations.

The syntax consists of 2 additions:
  - A new RuleClause:
```
"forall" Occurrence ":" Var "in" Names "=> {"
    {RuleClause ",\n"}+ "."
"}"
```

that can iterate over all occurrences in a namespace. It brings the occurrence name and associated type in scope for each RuleClause.

  - A new relation definition which can take 2 arbitrary types
and a relation operator. The pattern matching construct also takes
a list of ruleclauses that will be generated when evaluating the
relation. This can take an arbitrary ruleclause, including the new
proposed "forall".

An example of this syntax is the following:

```
relations
    	sub: Type * Type {
    		List(asdasd) <sub! List(asds) := {
    			true.
    		},
    		RECORD(one) <sub! RECORD(other) := {
    			forall Field{d1}:ty1 in D(one) => {
    				Field{d1} -> other,
    				Field{d1} |-> d2,
    				d2 : ty2,
    				ty1 <sub? ty2.
			}.
		}
    	}
```

In this example the UNION type does not generate any constraints.
The RECORD type does which uses the forall ruleclause directly.

### Reasoning
The new syntax is flexible in two ways:
- You can generate arbitrary new constraints when evaluating a relation, this is not limited to a specific subset
- The forall can also be used for other usecases, making it generic enough.

There is one note we have to make: since forall needs more constraints, it introduces nesting in the language. For nesting to parse nicely, we introduced brackets to actually know when the forall statements was finished.

However, as we also set that it is a list of constraints, it requires the regular separation by `,` and should end with a `.`. This might be a bit confusing, we are not sure how to address this properly. We tried different combinations with no brackets, just dots, etc.. but it would not be non-ambigous nor readable. This syntax was the best for both worlds in our opinion